### PR TITLE
fix: Pin Triton version in TPU diffusion notebook

### DIFF
--- a/examples/tpu_diffusion_finetuning.ipynb
+++ b/examples/tpu_diffusion_finetuning.ipynb
@@ -71,6 +71,7 @@
         "# Install necessary libraries\n",
         "!pip install --no-deps diffusers Pillow transformers bitsandbytes accelerate xformers==0.0.29.post3 peft trl==0.15.2 triton cut_cross_entropy unsloth_zoo sentencepiece protobuf datasets huggingface_hub hf_transfer multiprocess xxhash dill\n",
         "!pip install --no-deps \"unsloth[tpu] @ git+https://github.com/Sweaterdog/unsloth.git\" # Install Unsloth with TPU extras from Sweaterdog's fork\n",
+        "!pip install --no-deps unsloth_zoo triton==2.2.0 # Pinned Triton version\n",
         "!pip install --force-reinstall torch_xla\n",
         "\n",
         "# Verify torch_xla installation (optional)\n",


### PR DESCRIPTION
Updates the installation cell in
`examples/tpu_diffusion_finetuning.ipynb`
to install `triton==2.2.0` instead of the latest version.

This change is an attempt to resolve an issue where importing `torch_xla.core.xla_model` would fail due to an internal Triton import error (`cannot import name 'AttrsDescriptor'`). It is hypothesized that the latest Triton version (3.x) may have compatibility issues with the `torch_xla` versions typically used or available in Colab (e.g., 2.6.0 or 2.7.0). Pinning to Triton 2.2.0, a known stable version with older PyTorch/XLA releases, might provide better compatibility.