### PR TITLE
fix: Pin triton==2.2.0 in TPU diffusion notebook install cell

### DIFF
--- a/examples/tpu_diffusion_finetuning.ipynb
+++ b/examples/tpu_diffusion_finetuning.ipynb
@@ -69,9 +69,10 @@
       "outputs": [],
       "source": [
         "# Install necessary libraries\n",
-        "!pip install --no-deps diffusers Pillow transformers bitsandbytes accelerate xformers==0.0.29.post3 peft trl==0.15.2 triton cut_cross_entropy unsloth_zoo sentencepiece protobuf datasets huggingface_hub hf_transfer multiprocess xxhash dill\n",
+        "!pip install --no-deps diffusers Pillow transformers bitsandbytes accelerate xformers==0.0.29.post3 peft trl==0.15.2 cut_cross_entropy unsloth_zoo sentencepiece protobuf datasets huggingface_hub hf_transfer multiprocess xxhash dill\n",
         "!pip install --no-deps \"unsloth[tpu] @ git+https://github.com/Sweaterdog/unsloth.git\" # Install Unsloth with TPU extras from Sweaterdog's fork\n",
-        "!pip install --no-deps unsloth_zoo triton==2.2.0 # Pinned Triton version\n",
+        "!pip install triton==2.2.0 --no-deps # Explicitly install pinned Triton\n",
+        "!pip install --no-deps unsloth_zoo # Re-ensure unsloth_zoo\n",
         "!pip install --force-reinstall torch_xla\n",
         "\n",
         "# Verify torch_xla installation (optional)\n",
@@ -650,3 +651,5 @@
   "nbformat": 4,
   "nbformat_minor": 5
 }
+
+[end of examples/tpu_diffusion_finetuning.ipynb]


### PR DESCRIPTION
I've updated the installation cell in
`examples/tpu_diffusion_finetuning.ipynb` to:
1. Remove `triton` from the general `--no-deps` pip install line.
2. Add a specific line `!pip install triton==2.2.0 --no-deps`.
3. Ensure `unsloth_zoo` is also installed with `--no-deps`.

This change is crucial to resolve an `ImportError` within `torch_xla` (specifically `cannot import name 'AttrsDescriptor' from 'triton.compiler.compiler'`). This error occurred due to an incompatibility between the version of `torch_xla` used in Colab and the latest `triton` (v3.x.x) that was being installed as a dependency.

Pinning to `triton==2.2.0` is expected to provide a compatible version, allowing `torch_xla` to import correctly, which in turn will allow Unsloth's TPU device detection to succeed.